### PR TITLE
Add web.xml and remove Servlet 3.0 annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 tomcat.8080
+.classpath
+.project
+.settings/

--- a/src/main/java/launch/Main.java
+++ b/src/main/java/launch/Main.java
@@ -1,6 +1,10 @@
 package launch;
 import java.io.File;
+
+import org.apache.catalina.Context;
 import org.apache.catalina.startup.Tomcat;
+
+import servlet.HelloServlet;
 
 public class Main {
 
@@ -18,7 +22,10 @@ public class Main {
 
         tomcat.setPort(Integer.valueOf(webPort));
 
-        tomcat.addWebapp("/", new File(webappDirLocation).getAbsolutePath());
+        Context ctx = tomcat.addWebapp("/", new File(webappDirLocation).getAbsolutePath());
+        //the context object can be used to configure your server with settings that would normally go in your context.xml
+        //ctx.setUseHttpOnly(true);
+        
         System.out.println("configuring app with basedir: " + new File("./" + webappDirLocation).getAbsolutePath());
 
         tomcat.start();

--- a/src/main/java/servlet/HelloServlet.java
+++ b/src/main/java/servlet/HelloServlet.java
@@ -2,6 +2,7 @@ package servlet;
 
 import java.io.IOException;
 
+import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.annotation.WebServlet;
@@ -9,17 +10,26 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-@WebServlet(
-        name = "MyServlet", 
-        urlPatterns = {"/hello"}
-    )
 public class HelloServlet extends HttpServlet {
 
+	
     @Override
+	public void init() throws ServletException {
+		System.out.println("initializing HelloServlet");
+		super.init();
+	}
+    
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+    	System.out.println("initializing HelloServlet");
+    	super.init();
+    }
+
+	@Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp)
             throws ServletException, IOException {
         ServletOutputStream out = resp.getOutputStream();
-        out.write("hello heroku".getBytes());
+        out.write("hello heroku!!!".getBytes());
         out.flush();
         out.close();
     }

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    version="2.5">
+
+  <servlet>
+    <servlet-name>hello</servlet-name>
+    <servlet-class>servlet.HelloServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>hello</servlet-name>
+    <url-pattern>/hello</url-pattern>
+  </servlet-mapping>
+
+</web-app>


### PR DESCRIPTION
The embedded Tomcat container initialization won't read Servlet 3.0 annotations from anywhere except jars in the classpath or WEB-INF/classes. This is fine for appassembler scripts because the jar of the app itself goes on the classpath. However it's an issue when launching from Eclipse. The Servlet in the demo doesn't work.

Another way around this would be to drop the web.xml and use programmatic servlet registration:

```
    Tomcat.addServlet(ctx, "MyServlet", "servlet.HelloServlet");
    ctx.addServletMapping("/hello", "MyServlet");
```

The Servlet 3.0 annotations would still have to be removed.

Will make updates to the article after I get any feedback on this change.
